### PR TITLE
Add pytest unit tests for core functions

### DIFF
--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -23,6 +23,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     
+    - name: Run unit tests
+      run: |
+        echo "🧪 Running unit tests..."
+        python -m pytest tests/ -v
+
     - name: Validate manifest syntax
       run: |
         echo "🔍 Validating manifest syntax and structure..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 # Python dependencies for GitOps deployment scripts
 requests>=2.28.0
 PyYAML>=6.0
+pytest>=7.0.0
+responses>=0.23.0

--- a/tests/test_compile_manifests.py
+++ b/tests/test_compile_manifests.py
@@ -1,0 +1,113 @@
+"""Tests for manifest compilation (scripts/compile_manifests.py)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+from compile_manifests import _meta_data, to_application
+
+
+# ---------------------------------------------------------------------------
+# _meta_data
+# ---------------------------------------------------------------------------
+
+class TestMetaData:
+    def test_basic_hostname(self):
+        result = _meta_data('my-host')
+        assert 'local-hostname: "my-host"' in result
+        assert 'dsmode: local' in result
+
+    def test_empty_name_falls_back_to_vm(self):
+        result = _meta_data('')
+        assert 'local-hostname: "vm"' in result
+
+
+# ---------------------------------------------------------------------------
+# to_application
+# ---------------------------------------------------------------------------
+
+class TestToApplication:
+    @staticmethod
+    def _container_def():
+        return {
+            'type': 'ContainerDefinition',
+            'metadata': {
+                'name': 'test-app',
+                'clusterGroups': ['TestGroup'],
+            },
+            'spec': {
+                'containers': [
+                    {
+                        'name': 'nginx',
+                        'image': 'docker.io/library/nginx:latest',
+                        'ports': ['80:80'],
+                    },
+                ],
+                'content': [],
+            },
+        }
+
+    @staticmethod
+    def _runtime_def():
+        return {
+            'version': '1',
+            'type': 'RuntimeConfiguration',
+            'metadata': {'name': 'default-runtime'},
+            'spec': {
+                'cloudInit': {
+                    'ssh': {'passwordAuth': True, 'disableRoot': False},
+                },
+                'runtime': {
+                    'vcpus': 2,
+                    'memory': '2Gi',
+                    'disk': {
+                        'name': 'rootdisk',
+                        'capacity': '40Gi',
+                        'format': 'raw',
+                        'url': 'https://example.com/disk.raw',
+                    },
+                },
+                'network': [{'name': 'eth0', 'type': 'virtio'}],
+                'vmState': 'running',
+                'policies': {
+                    'enablePodmanSocket': True,
+                    'enableAutoUpdateTimer': True,
+                    'setupQemuGuestAgent': False,
+                    'rebootAfterQga': False,
+                    'autoUpdateLabel': True,
+                },
+            },
+        }
+
+    def test_output_type_and_version(self):
+        app = to_application(self._container_def(), self._runtime_def())
+        assert app['type'] == 'Application'
+        assert app['version'] == '1'
+
+    def test_metadata_name(self):
+        app = to_application(self._container_def(), self._runtime_def())
+        assert app['metadata']['name'] == 'test-app'
+
+    def test_assets_contains_virtual_disk(self):
+        app = to_application(self._container_def(), self._runtime_def())
+        assets = app['spec']['assets']
+        assert any(a['type'] == 'virtual_disk' for a in assets)
+
+    def test_resources_contains_virdomain(self):
+        app = to_application(self._container_def(), self._runtime_def())
+        resources = app['spec']['resources']
+        assert any(r['type'] == 'virdomain' for r in resources)
+
+    def test_cloud_init_data_populated(self):
+        app = to_application(self._container_def(), self._runtime_def())
+        virdomain = [r for r in app['spec']['resources'] if r['type'] == 'virdomain'][0]
+        cloud_init = virdomain['spec']['cloud_init_data']
+        assert 'user_data' in cloud_init
+        assert 'meta_data' in cloud_init
+
+    def test_rendered_user_data_key_present(self):
+        """to_application attaches __rendered_user_data__ for later YAML emission."""
+        app = to_application(self._container_def(), self._runtime_def())
+        assert '__rendered_user_data__' in app
+        assert '#cloud-config' in app['__rendered_user_data__']

--- a/tests/test_destructive_changes.py
+++ b/tests/test_destructive_changes.py
@@ -1,0 +1,68 @@
+"""Tests for destructive change detection."""
+
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch):
+    monkeypatch.setenv('SC_FM_APIKEY', 'dummy')
+
+
+@pytest.fixture
+def fm():
+    from deploy import FleetManagerGitOps
+    return FleetManagerGitOps()
+
+
+def _make_manifest(vm_name='test-vm', user_data='#cloud-config\nruncmd: []'):
+    """Helper to build a minimal manifest with a virdomain resource."""
+    return {
+        'spec': {
+            'resources': [
+                {
+                    'type': 'virdomain',
+                    'name': vm_name,
+                    'spec': {
+                        'cloud_init_data': {
+                            'user_data': user_data,
+                        }
+                    }
+                }
+            ]
+        }
+    }
+
+
+class TestDetectDestructiveChanges:
+    def test_no_existing_manifest_returns_empty(self, fm):
+        warnings = fm.detect_destructive_changes('app1', _make_manifest(), None)
+        assert warnings == []
+
+    def test_same_cloud_init_no_warning(self, fm):
+        manifest = _make_manifest(user_data='#cloud-config\nfoo: bar')
+        existing = _make_manifest(user_data='#cloud-config\nfoo: bar')
+        warnings = fm.detect_destructive_changes('app1', manifest, existing)
+        cloud_init_warnings = [w for w in warnings if 'cloud-init' in w.lower() or 'cloud_init' in w.lower() or 'user_data' in w.lower()]
+        assert cloud_init_warnings == []
+
+    def test_changed_cloud_init_user_data_warns(self, fm):
+        new = _make_manifest(user_data='#cloud-config\nnew: data')
+        existing = _make_manifest(user_data='#cloud-config\nold: data')
+        warnings = fm.detect_destructive_changes('app1', new, existing)
+        assert any('user_data' in w.lower() or 'cloud' in w.lower() for w in warnings)
+
+    def test_changed_vm_name_warns(self, fm):
+        new = _make_manifest(vm_name='new-vm')
+        existing = _make_manifest(vm_name='old-vm')
+        warnings = fm.detect_destructive_changes('app1', new, existing)
+        assert any('name' in w.lower() for w in warnings)
+
+    def test_no_changes_empty_warnings(self, fm):
+        manifest = _make_manifest()
+        existing = _make_manifest()
+        warnings = fm.detect_destructive_changes('app1', manifest, existing)
+        assert warnings == []

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,87 @@
+"""Tests for manifest lifecycle detection and skip logic."""
+
+import os
+import sys
+import pytest
+
+# Add scripts/ to path so we can import deploy module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch):
+    """Set required env var so FleetManagerGitOps can be instantiated."""
+    monkeypatch.setenv('SC_FM_APIKEY', 'dummy')
+
+
+@pytest.fixture
+def fm():
+    from deploy import FleetManagerGitOps
+    return FleetManagerGitOps()
+
+
+# ---------------------------------------------------------------------------
+# get_manifest_lifecycle_state
+# ---------------------------------------------------------------------------
+
+class TestGetManifestLifecycleState:
+    def test_draft(self, fm):
+        manifest = {'metadata': {'lifecycle': 'draft'}}
+        assert fm.get_manifest_lifecycle_state(manifest) == 'draft'
+
+    def test_testonly(self, fm):
+        manifest = {'metadata': {'lifecycle': 'testonly'}}
+        assert fm.get_manifest_lifecycle_state(manifest) == 'testonly'
+
+    def test_production(self, fm):
+        manifest = {'metadata': {'lifecycle': 'production'}}
+        assert fm.get_manifest_lifecycle_state(manifest) == 'production'
+
+    def test_undeploy(self, fm):
+        manifest = {'metadata': {'lifecycle': 'undeploy'}}
+        assert fm.get_manifest_lifecycle_state(manifest) == 'undeploy'
+
+    def test_legacy_draft_flag(self, fm):
+        manifest = {'metadata': {'draft': True}}
+        assert fm.get_manifest_lifecycle_state(manifest) == 'draft'
+
+    def test_no_lifecycle_field(self, fm):
+        manifest = {'metadata': {'name': 'some-app'}}
+        assert fm.get_manifest_lifecycle_state(manifest) == 'production'
+
+    def test_empty_metadata(self, fm):
+        manifest = {'metadata': {}}
+        assert fm.get_manifest_lifecycle_state(manifest) == 'production'
+
+
+# ---------------------------------------------------------------------------
+# should_skip_manifest
+# ---------------------------------------------------------------------------
+
+class TestShouldSkipManifest:
+    def test_draft_skipped(self, fm):
+        skip, reason = fm.should_skip_manifest({}, 'draft')
+        assert skip is True
+        assert 'draft' in reason.lower()
+
+    def test_testonly_no_test_mode_skipped(self, fm):
+        fm.test_mode = False
+        skip, reason = fm.should_skip_manifest({}, 'testonly')
+        assert skip is True
+        assert 'test' in reason.lower()
+
+    def test_testonly_with_test_mode_not_skipped(self, fm):
+        fm.test_mode = True
+        skip, reason = fm.should_skip_manifest({}, 'testonly')
+        assert skip is False
+        assert reason == ''
+
+    def test_production_not_skipped(self, fm):
+        skip, reason = fm.should_skip_manifest({}, 'production')
+        assert skip is False
+        assert reason == ''
+
+    def test_undeploy_skipped(self, fm):
+        skip, reason = fm.should_skip_manifest({}, 'undeploy')
+        assert skip is True
+        assert 'undeploy' in reason.lower()

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,75 @@
+"""Tests for manifest normalization."""
+
+import os
+import sys
+import copy
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+from deploy import FleetManagerGitOps
+
+
+class TestNormalizeManifestStructure:
+    """Test FleetManagerGitOps._normalize_manifest_structure (staticmethod)."""
+
+    def test_labels_dict_converted_to_list(self):
+        manifest = {
+            'metadata': {
+                'name': 'test',
+                'labels': {'env': 'prod', 'team': 'ops'},
+            },
+            'spec': {},
+        }
+        result = FleetManagerGitOps._normalize_manifest_structure(manifest)
+        labels = result['metadata']['labels']
+        assert isinstance(labels, list)
+        label_keys = {item['key'] for item in labels}
+        assert label_keys == {'env', 'team'}
+        for item in labels:
+            if item['key'] == 'env':
+                assert item['value'] == 'prod'
+            elif item['key'] == 'team':
+                assert item['value'] == 'ops'
+
+    def test_labels_already_list_unchanged(self):
+        original_labels = [{'key': 'env', 'value': 'prod'}]
+        manifest = {
+            'metadata': {
+                'name': 'test',
+                'labels': copy.deepcopy(original_labels),
+            },
+            'spec': {},
+        }
+        result = FleetManagerGitOps._normalize_manifest_structure(manifest)
+        assert result['metadata']['labels'] == original_labels
+
+    def test_cloud_init_user_data_trailing_whitespace_stripped(self):
+        manifest = {
+            'metadata': {'name': 'test'},
+            'spec': {
+                'resources': [
+                    {
+                        'type': 'virdomain',
+                        'spec': {
+                            'cloud_init_data': {
+                                'user_data': '#cloud-config\nruncmd:\n  - echo hello\n   \n  '
+                            }
+                        }
+                    }
+                ]
+            },
+        }
+        result = FleetManagerGitOps._normalize_manifest_structure(manifest)
+        user_data = result['spec']['resources'][0]['spec']['cloud_init_data']['user_data']
+        assert not user_data.endswith(' ')
+        assert not user_data.endswith('\n   \n  ')
+
+    def test_manifest_without_labels_or_cloud_init(self):
+        manifest = {
+            'metadata': {'name': 'test'},
+            'spec': {'assets': []},
+        }
+        original = copy.deepcopy(manifest)
+        result = FleetManagerGitOps._normalize_manifest_structure(manifest)
+        assert result['metadata'] == original['metadata']
+        assert result['spec'] == original['spec']

--- a/tests/test_validate_manifests.py
+++ b/tests/test_validate_manifests.py
@@ -1,0 +1,111 @@
+"""Tests for the manifest validator (scripts/validate-manifests.py)."""
+
+import os
+import sys
+import importlib
+import tempfile
+import pytest
+import yaml
+
+# The file is named validate-manifests.py (hyphenated), so use importlib
+_scripts_dir = os.path.join(os.path.dirname(__file__), '..', 'scripts')
+sys.path.insert(0, _scripts_dir)
+
+_spec = importlib.util.spec_from_file_location(
+    'validate_manifests',
+    os.path.join(_scripts_dir, 'validate-manifests.py'),
+)
+validate_manifests = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(validate_manifests)
+ManifestValidator = validate_manifests.ManifestValidator
+
+
+@pytest.fixture
+def validator():
+    return ManifestValidator()
+
+
+# ---------------------------------------------------------------------------
+# validate_manifest_structure
+# ---------------------------------------------------------------------------
+
+class TestValidateManifestStructure:
+    def test_valid_application(self, validator):
+        manifest = {
+            'type': 'Application',
+            'metadata': {'name': 'test-app'},
+            'spec': {
+                'assets': [
+                    {'name': 'disk1', 'type': 'virtual_disk'},
+                ],
+            },
+        }
+        assert validator.validate_manifest_structure(manifest, 'test.yaml') is True
+
+    def test_missing_metadata_name(self, validator):
+        manifest = {
+            'type': 'Application',
+            'metadata': {},
+            'spec': {
+                'assets': [
+                    {'name': 'disk1', 'type': 'virtual_disk'},
+                ],
+            },
+        }
+        assert validator.validate_manifest_structure(manifest, 'test.yaml') is False
+
+    def test_missing_spec_assets_still_fails(self, validator):
+        """Assets are required by the validator's current implementation."""
+        manifest = {
+            'type': 'Application',
+            'metadata': {'name': 'test-app'},
+            'spec': {},
+        }
+        assert validator.validate_manifest_structure(manifest, 'test.yaml') is False
+
+    def test_asset_with_invalid_type(self, validator):
+        manifest = {
+            'type': 'Application',
+            'metadata': {'name': 'test-app'},
+            'spec': {
+                'assets': [
+                    {'name': 'disk1', 'type': 'invalid_type'},
+                ],
+            },
+        }
+        assert validator.validate_manifest_structure(manifest, 'test.yaml') is False
+
+    def test_non_application_skipped_via_validate_manifest(self, validator, tmp_path):
+        """Non-Application type manifests are skipped (returns True) via validate_manifest."""
+        manifest = {
+            'type': 'ContainerDefinition',
+            'metadata': {'name': 'test-container'},
+            'spec': {},
+        }
+        f = tmp_path / 'container.yaml'
+        f.write_text(yaml.dump(manifest))
+        # validate_manifest skips non-Application types and returns True
+        assert validator.validate_manifest(str(f)) is True
+
+
+# ---------------------------------------------------------------------------
+# validate_yaml_syntax
+# ---------------------------------------------------------------------------
+
+class TestValidateYamlSyntax:
+    def test_valid_yaml(self, validator, tmp_path):
+        f = tmp_path / 'valid.yaml'
+        f.write_text('key: value\nlist:\n  - item1\n')
+        assert validator.validate_yaml_syntax(str(f)) is True
+
+    def test_invalid_yaml(self, validator, tmp_path):
+        f = tmp_path / 'invalid.yaml'
+        # Tabs mixed with spaces and unquoted special chars produce a YAML error
+        f.write_text('key: value\n\t bad: indent\n  nested:\n    - [unclosed\n')
+        assert validator.validate_yaml_syntax(str(f)) is False
+
+    def test_empty_file(self, validator, tmp_path):
+        f = tmp_path / 'empty.yaml'
+        f.write_text('')
+        # yaml.safe_load returns None for empty files; no exception raised
+        assert validator.validate_yaml_syntax(str(f)) is True


### PR DESCRIPTION
## Summary
- Add pytest unit tests covering lifecycle state detection, manifest normalization, destructive change detection, YAML validation, and container-to-application compilation
- Update requirements.txt with pytest and responses dependencies
- Add pyproject.toml with pytest configuration
- Add pytest step to validate-manifests CI workflow

## Test files
| File | What it tests |
|------|--------------|
| `tests/test_lifecycle.py` | `get_manifest_lifecycle_state()` and `should_skip_manifest()` |
| `tests/test_normalize.py` | `_normalize_manifest_structure()` — labels dict-to-list, cloud-init whitespace |
| `tests/test_destructive_changes.py` | `detect_destructive_changes()` — cloud-init and VM name changes |
| `tests/test_validate_manifests.py` | `ManifestValidator` — structure validation and YAML syntax |
| `tests/test_compile_manifests.py` | `_meta_data()` and `to_application()` — manifest compilation |

## Test plan
- [ ] Run `python -m pytest tests/ -v` locally and verify all tests pass
- [ ] Verify CI workflow runs pytest step on PR

Closes #41

Generated with [Claude Code](https://claude.com/claude-code)